### PR TITLE
Update README.md and GitHub Action to build and test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         id: checkout_code
         
       - name: Setup MSBuild path
-        uses: warrenbuckley/Setup-MSBuild@v1
+        uses: microsoft/setup-msbuild@v1
         id: setup_msbuild
         
       - name: Run MSBuild
@@ -41,5 +41,3 @@ jobs:
       - name: Setup VSTest path
         uses: darenm/Setup-VSTest@v1
         id: setup_vstest
-          
-# where I think tests are found: ${{ github.workspace }}\Debug\UnitTests.dll

--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@
 A Tic-Tac-Toe game for the command line.
 
 ![Build and Test](https://github.com/tessapower/tictactoe/workflows/Build%20and%20Test/badge.svg?branch=master)
+
+Read more about this project [here](https://tessapower.co).


### PR DESCRIPTION
Merging this PR will make a simple edit to `README.md` and swap out the GitHub Action from Warren Buckley that set up MSBuild with the official Microsoft GitHub Action to setup MSBuild.